### PR TITLE
feat(ci): add manual pre-release workflow

### DIFF
--- a/.github/docs/RELEASE_PROCESS.md
+++ b/.github/docs/RELEASE_PROCESS.md
@@ -113,6 +113,36 @@ The release pipeline is fully driven by merges to `main`, so the "manual" path i
 
 If a release ever needs to be re-run (e.g. asset upload failed), re-run the `CD` workflow from the Actions tab — `release.yml` is idempotent against existing tags.
 
+## Cutting a pre-release (RC / beta / alpha)
+
+When you want to ship a build for QA / external validation **without** bumping the official `VERSION` or touching `main`, use the manual `prerelease.yml` workflow.
+
+1. Go to **Actions → Pre-release → Run workflow**.
+2. Fill the inputs:
+   - **`version`** (required): semver pre-release suffix is mandatory, e.g. `0.3.0-rc.1`, `0.3.0-beta.2`, `0.3.0-alpha.1`. The workflow validates this with a regex and rejects bad inputs.
+   - **`ref`** (default `main`): branch, tag, or SHA to build from. Useful to pre-release a `feature/*` before merging.
+   - **`draft`** (default `false`): publish as a draft so you can sanity-check the assets before going public.
+3. Click **Run workflow**.
+
+What it does:
+
+- Builds the per-engine ZIPs at the chosen ref via `use-build.yml` (passing `version_override`, so the version comes from the dispatch input — no need to change `VERSION`).
+- Refuses to run if `v<version>` already exists.
+- Creates the annotated git tag `v<version>` on the chosen ref.
+- Publishes a GitHub Release marked **`prerelease: true`** with auto-generated notes and the 14 versioned ZIP assets.
+- **Does not** create permalink ZIPs (e.g. `teradata.zip`). Permalinks remain pinned to the latest **stable** release so consumers that pin to "latest" are not surprised by an RC.
+
+Recommended flow when working towards a `0.3.0` release:
+
+```
+1. Dispatch Pre-release with version=0.3.0-rc.1
+   → publishes v0.3.0-rc.1 as prerelease for QA
+2. QA validates the ZIPs of the RC
+3. If issues are found, fix on a branch and dispatch 0.3.0-rc.2 (etc.)
+4. When the RC is approved: open a PR that bumps VERSION to 0.3.0 + runs ./VERSION-UPDATE.sh
+5. Merge to main → CD publishes v0.3.0 as the stable release
+```
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |

--- a/.github/docs/WORKFLOWS.md
+++ b/.github/docs/WORKFLOWS.md
@@ -23,12 +23,13 @@ Naming follows the convention used across the `migrations-*` repos:
 |---|---|---|
 | [`prepare-release.yml`](../workflows/prepare-release.yml) | `cd.yml` | Reads `VERSION`, computes the three version forms, creates the `v<X.Y.Z>` git tag (only on `main`). |
 | [`release.yml`](../workflows/release.yml) | `cd.yml` (only on `main`) | Builds the ZIPs, generates release notes, creates permalink ZIPs, publishes the GitHub Release with all assets. |
+| [`prerelease.yml`](../workflows/prerelease.yml) | Manual `workflow_dispatch` | Builds at any ref and publishes a GitHub **Pre-release** (`v<X.Y.Z>-rc.N` etc.). Does not touch `VERSION`, `main`, or permalink ZIPs. |
 
 ## Reusable building blocks
 
 | File | Called by | Purpose |
 |---|---|---|
-| [`use-build.yml`](../workflows/use-build.yml) | `ci.yml`, `release.yml` | Validates required engine folders, zips each engine into `<engine>_v<X.Y.Z>.zip`, verifies, and uploads as an artifact. Exposes `version`, `version_dots`, `version_clean` outputs. |
+| [`use-build.yml`](../workflows/use-build.yml) | `ci.yml`, `release.yml`, `prerelease.yml` | Validates required engine folders, zips each engine into `<engine>_v<X.Y.Z>.zip`, verifies, and uploads as an artifact. Exposes `version`, `version_dots`, `version_clean` outputs. Accepts an optional `version_override` input (used by `prerelease.yml`) so the version can come from the dispatch input instead of the `VERSION` file. |
 
 ## PR checks
 
@@ -40,19 +41,19 @@ Naming follows the convention used across the `migrations-*` repos:
 ## Dependency graph
 
 ```
-                push to main / PR
-                         │
-                         ▼
-                      cd.yml
-                    /        \
-                   ▼          ▼
-       prepare-release.yml   (is_main?)
-                              /     \
-                       yes  ▼       ▼ no
-                       release.yml  ci.yml
-                              \     /
-                               ▼   ▼
-                            use-build.yml
+                push to main / PR                  workflow_dispatch
+                         │                                │
+                         ▼                                ▼
+                      cd.yml                       prerelease.yml
+                    /        \                            │
+                   ▼          ▼                           │
+       prepare-release.yml   (is_main?)                   │
+                              /     \                     │
+                       yes  ▼       ▼ no                  │
+                       release.yml  ci.yml                │
+                              \     /                     │
+                               ▼   ▼                      ▼
+                            use-build.yml ◄───────────────┘
 ```
 
-For a deeper explanation of the release flow, see [`RELEASE_PROCESS.md`](./RELEASE_PROCESS.md).
+For a deeper explanation of the release flow (including pre-releases), see [`RELEASE_PROCESS.md`](./RELEASE_PROCESS.md).

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,142 @@
+name: Pre-release
+
+# Manual pre-release pipeline.
+#
+# Builds the per-engine ZIPs at the chosen ref and publishes a GitHub Release
+# marked as `prerelease: true`, tagged `v<version>` (e.g. v0.3.0-rc.1).
+#
+# Notes:
+# - Does NOT touch the VERSION file or the main branch. The "real" release is
+#   still cut by cd.yml on merge to main once VERSION is bumped.
+# - Permalink ZIPs (e.g. teradata.zip) are NOT updated by this workflow — those
+#   are reserved for stable releases so consumers that pin to "latest stable"
+#   are not surprised by an RC.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Pre-release version, semver pre-release suffix required (e.g. 0.3.0-rc.1, 0.3.0-beta.1, 0.3.0-alpha.1).'
+        required: true
+        type: string
+      ref:
+        description: 'Branch, tag, or SHA to build from.'
+        required: false
+        default: main
+        type: string
+      draft:
+        description: 'Publish as a draft release (no notifications) so you can review assets before going public.'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    name: Validate input
+    runs-on: ubuntu-latest
+    outputs:
+      version_clean: ${{ steps.check.outputs.version_clean }}
+    steps:
+      - name: Validate semver pre-release format
+        id: check
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          # Accept: X.Y.Z-(alpha|beta|rc).N  optionally prefixed by 'v'
+          CLEAN="${VERSION_INPUT#v}"
+          if ! echo "${CLEAN}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$'; then
+            echo "::error::'${VERSION_INPUT}' is not a valid pre-release version. Expected format: X.Y.Z-(alpha|beta|rc).N (e.g. 0.3.0-rc.1)."
+            exit 1
+          fi
+          echo "version_clean=${CLEAN}" >> "${GITHUB_OUTPUT}"
+          echo "Validated pre-release version: ${CLEAN} (will be tagged as v${CLEAN})"
+
+  build-assets:
+    name: Build Pre-release Assets
+    needs: validate
+    uses: ./.github/workflows/use-build.yml
+    with:
+      artifact_name: ddl-export-scripts-prerelease
+      artifact_retention_days: 14
+      version_override: ${{ needs.validate.outputs.version_clean }}
+
+  publish:
+    name: Publish GitHub Pre-release
+    needs: [validate, build-assets]
+    runs-on: ubuntu-latest
+    env:
+      VERSION_CLEAN: ${{ needs.validate.outputs.version_clean }}
+      VERSION_DOTS: ${{ needs.build-assets.outputs.version_dots }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Verify tag does not already exist
+        run: |
+          git fetch --tags
+          if git tag -l "v${VERSION_CLEAN}" | grep -q "v${VERSION_CLEAN}"; then
+            echo "::error::Tag v${VERSION_CLEAN} already exists. Pick a higher pre-release number (e.g. 0.3.0-rc.2)."
+            exit 1
+          fi
+          echo "Tag v${VERSION_CLEAN} is free."
+
+      - name: Download pre-release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ddl-export-scripts-prerelease-v${{ env.VERSION_CLEAN }}
+          path: ./prerelease-assets
+
+      - name: List downloaded assets
+        run: ls -la ./prerelease-assets
+
+      - name: Create annotated git tag
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION_CLEAN}" -m "Pre-release v${VERSION_CLEAN} from ${{ inputs.ref }} (${{ github.sha }})"
+          git push origin "v${VERSION_CLEAN}"
+
+      - name: Publish GitHub Pre-release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ env.VERSION_CLEAN }}
+          name: Pre-release v${{ env.VERSION_CLEAN }}
+          target_commitish: ${{ inputs.ref }}
+          generate_release_notes: true
+          prerelease: true
+          draft: ${{ inputs.draft }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            ./prerelease-assets/db2_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/hive_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/netezza_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/oracle_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/redshift_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/sql-server_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/teradata_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/vertica_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/bigquery_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/databricks_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/AlternativeSQLServerExtractionMethods_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/synapse_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/sybase-iq_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/power-bi_v${{ env.VERSION_DOTS }}.zip
+
+      - name: Summary
+        run: |
+          {
+            echo "### Pre-release published"
+            echo ""
+            echo "- **Tag:** \`v${VERSION_CLEAN}\`"
+            echo "- **Source ref:** \`${{ inputs.ref }}\` (\`${{ github.sha }}\`)"
+            echo "- **Draft:** \`${{ inputs.draft }}\`"
+            echo "- **URL:** https://github.com/${{ github.repository }}/releases/tag/v${VERSION_CLEAN}"
+            echo ""
+            echo "Permalink ZIPs (e.g. \`teradata.zip\`) were intentionally NOT updated."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -127,6 +127,7 @@ jobs:
             ./prerelease-assets/synapse_v${{ env.VERSION_DOTS }}.zip
             ./prerelease-assets/sybase-iq_v${{ env.VERSION_DOTS }}.zip
             ./prerelease-assets/power-bi_v${{ env.VERSION_DOTS }}.zip
+            ./prerelease-assets/informatica-powercenter_v${{ env.VERSION_DOTS }}.zip
 
       - name: Summary
         run: |

--- a/.github/workflows/use-build.yml
+++ b/.github/workflows/use-build.yml
@@ -22,6 +22,11 @@ on:
         default: 30
         required: false
         type: number
+      version_override:
+        description: "If set, use this version instead of reading the VERSION file (used by the manual pre-release workflow, e.g. '0.3.0-rc.1')"
+        default: ""
+        required: false
+        type: string
     outputs:
       version:
         description: "The version extracted from VERSION file"
@@ -49,23 +54,29 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
         
-      - name: Extract version from VERSION file
+      - name: Resolve version (override or VERSION file)
         id: get_version
         working-directory: ${{ github.workspace }}
+        env:
+          VERSION_OVERRIDE: ${{ inputs.version_override }}
         run: |
-          # Get version with underscores for use in some places
-          VERSION=$(grep "__version__" VERSION | cut -d'"' -f2 | tr '.' '_')
+          if [ -n "${VERSION_OVERRIDE}" ]; then
+            RAW_VERSION="${VERSION_OVERRIDE}"
+            echo "Using version_override: ${RAW_VERSION}"
+          else
+            RAW_VERSION=$(grep "__version__" VERSION | cut -d'"' -f2)
+            echo "Using version from VERSION file: ${RAW_VERSION}"
+          fi
+
+          VERSION_CLEAN=$(echo "${RAW_VERSION}" | sed 's/^v//g')
+          VERSION_DOTS="${VERSION_CLEAN}"
+          VERSION=$(echo "${VERSION_CLEAN}" | tr '.' '_')
+
           echo "VERSION=${VERSION}" >> "${GITHUB_OUTPUT}"
-
-          # Get original version with dots for use in file names
-          VERSION_DOTS=$(grep "__version__" VERSION | cut -d'"' -f2)
           echo "VERSION_DOTS=${VERSION_DOTS}" >> "${GITHUB_OUTPUT}"
-
-          # Get clean version without any 'v' prefix to ensure we don't get double v's
-          VERSION_CLEAN=$(grep "__version__" VERSION | cut -d'"' -f2 | sed 's/^v//g')
           echo "VERSION_CLEAN=${VERSION_CLEAN}" >> "${GITHUB_OUTPUT}"
 
-          echo "Version extracted: ${VERSION} (with underscores), ${VERSION_DOTS} (with dots), and ${VERSION_CLEAN} (clean without v prefix)"
+          echo "Resolved: ${VERSION} (underscored), ${VERSION_DOTS} (dotted), ${VERSION_CLEAN} (clean without v prefix)"
 
       - name: Validate directory structure
         run: |


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` pipeline that publishes a GitHub **Pre-release** for QA / external validation, without bumping `VERSION` or touching `main`.

This complements (not replaces) the existing CD flow:

| Path | Trigger | Purpose |
|---|---|---|
| Stable release | merge to `main` (after VERSION bump) | `cd.yml` → `release.yml` → tag `v<X.Y.Z>` + GitHub Release |
| **Pre-release (new)** | manual `workflow_dispatch` | `prerelease.yml` → tag `v<X.Y.Z>-rc.N` + GitHub Pre-release |

## How to use

Actions tab → **Pre-release** → Run workflow → fill inputs:

| Input | Default | Notes |
|---|---|---|
| `version` | (required) | Must match `X.Y.Z-(alpha\|beta\|rc).N`, e.g. `0.3.0-rc.1`. Validated up-front. |
| `ref` | `main` | Branch / tag / SHA to build from. Useful to RC a `feature/*` before merging. |
| `draft` | `false` | Publish as draft so you can review before going public. |

In ~3 minutes:
- Tag `v0.3.0-rc.1` is created on the chosen ref.
- A GitHub Release marked **Pre-release** is published with the 14 versioned ZIPs.
- It does **not** appear as "Latest" — stable consumers are not affected.

## Implementation

- **`.github/workflows/prerelease.yml`** (new): orchestrator with `validate` → `build-assets` → `publish` jobs.
- **`.github/workflows/use-build.yml`**: adds optional `version_override` input. When set, the version comes from the dispatch input instead of the `VERSION` file. Refactored the `Resolve version` step to handle both paths uniformly. Existing callers (`ci.yml`, `release.yml`) keep working unchanged.
- **`.github/docs/RELEASE_PROCESS.md`**: new section "Cutting a pre-release (RC / beta / alpha)" with the full RC → stable flow.
- **`.github/docs/WORKFLOWS.md`**: index + dependency graph updated.

## Design choices

| Decision | Why |
|---|---|
| `prerelease: true`, no permalink ZIPs | Permalinks like `teradata.zip` are an implicit contract for the public — they should only point to stable. |
| Doesn't touch `VERSION` or `main` | An RC shouldn't contaminate the official version. The actual `0.3.0` bump still happens in a normal PR + merge. |
| Strict semver pre-release regex | Forces discipline: rejects `0.3` or `v0.3.0-test` so pre-releases stay parseable and orderable. |
| Tag-already-exists guard | Avoids overwriting a published RC by accident. |
| `ref` input | Lets you RC a fix on a `feature/*` before mergning — speeds up validation cycles. |
| Reuses `use-build.yml` | DRY. Single source of truth for what gets packaged. |

## Test plan

- [ ] CI workflow runs on this PR.
- [ ] After merge, dispatch the new **Pre-release** workflow with `version=0.3.0-rc.1` and confirm:
  - [ ] Tag `v0.3.0-rc.1` is created.
  - [ ] GitHub Release is marked "Pre-release" (yellow badge), not "Latest".
  - [ ] 14 ZIPs (`teradata_v0.3.0-rc.1.zip`, etc.) are attached.
  - [ ] No `teradata.zip` / `oracle.zip` permalinks were touched.
  - [ ] Re-running with the same `version` fails with "tag already exists".
  - [ ] Running with an invalid version like `0.3.0` fails up-front.