### PR TITLE
feat(ci): include Informatica PowerCenter (PR #42) in release pipeline

### DIFF
--- a/.github/docs/RELEASE_PROCESS.md
+++ b/.github/docs/RELEASE_PROCESS.md
@@ -66,7 +66,7 @@ On a PR, step **C** still runs (read-only — it does not push a tag because `is
 
 `use-build.yml` packages each supported engine into its own ZIP and validates the directory exists first. Engines currently packaged:
 
-`DB2`, `Hive`, `Netezza`, `Oracle`, `Redshift`, `SQLServer`, `Teradata`, `Vertica`, `BigQuery`, `Databricks`, `Synapse`, `Sybase IQ`, `Power BI`, `AlternativeSQLServerExtractionMethods`.
+`DB2`, `Hive`, `Netezza`, `Oracle`, `Redshift`, `SQLServer`, `Teradata`, `Vertica`, `BigQuery`, `Databricks`, `Synapse`, `Sybase IQ`, `Power BI`, `AlternativeSQLServerExtractionMethods`, `ETL/Informatica PowerCenter`.
 
 Each engine produces **two** assets on the GitHub Release:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
           - Sybase IQ
           - Power BI
           - Alternative SQL Server Extraction Methods
+          - Informatica PowerCenter (ETL)
 
           ### Component Changes
           EOL
@@ -173,6 +174,7 @@ jobs:
           add_component_changes "Sybase IQ" "Sybase IQ/"
           add_component_changes "Power BI" "Power BI/"
           add_component_changes "Alternative SQL Server Extraction Methods" "AlternativeSQLServerExtractionMethods/"
+          add_component_changes "Informatica PowerCenter (ETL)" "ETL/Informatica PowerCenter/"
 
           # Add installation and usage instructions
           cat >> ./release_notes/release_notes.md << EOL
@@ -235,6 +237,7 @@ jobs:
           cp synapse_v${{ needs.build-assets.outputs.version_dots }}.zip synapse.zip
           cp sybase-iq_v${{ needs.build-assets.outputs.version_dots }}.zip sybase-iq.zip
           cp power-bi_v${{ needs.build-assets.outputs.version_dots }}.zip power-bi.zip
+          cp informatica-powercenter_v${{ needs.build-assets.outputs.version_dots }}.zip informatica-powercenter.zip
           
           echo "Permalink versions created:"
           ls -la *.zip
@@ -257,6 +260,7 @@ jobs:
             ./release-assets/synapse_v${{ needs.build-assets.outputs.version_dots }}.zip
             ./release-assets/sybase-iq_v${{ needs.build-assets.outputs.version_dots }}.zip
             ./release-assets/power-bi_v${{ needs.build-assets.outputs.version_dots }}.zip
+            ./release-assets/informatica-powercenter_v${{ needs.build-assets.outputs.version_dots }}.zip
             ./release-assets/db2.zip
             ./release-assets/hive.zip
             ./release-assets/netezza.zip
@@ -271,6 +275,7 @@ jobs:
             ./release-assets/synapse.zip
             ./release-assets/sybase-iq.zip
             ./release-assets/power-bi.zip
+            ./release-assets/informatica-powercenter.zip
           tag_name: ${{ steps.ensure_tag.outputs.release_tag }}
           name: Release ${{ steps.ensure_tag.outputs.release_tag }}
           body: ${{ steps.generate_release_notes.outputs.release_notes }}

--- a/.github/workflows/use-build.yml
+++ b/.github/workflows/use-build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Validate directory structure
         run: |
           # Verify that all required directories exist before packaging
-          for dir in DB2 Hive Netezza Oracle Redshift SQLServer Teradata Vertica BigQuery Databricks AlternativeSQLServerExtractionMethods Synapse "Sybase IQ" "Power BI"; do
+          for dir in DB2 Hive Netezza Oracle Redshift SQLServer Teradata Vertica BigQuery Databricks AlternativeSQLServerExtractionMethods Synapse "Sybase IQ" "Power BI" "ETL/Informatica PowerCenter"; do
             if [ ! -d "$dir" ]; then
               echo "Error: Directory '$dir' not found!"
               exit 1
@@ -176,6 +176,13 @@ jobs:
           recursive: false
           dest: power-bi_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip
 
+      - name: Build Informatica PowerCenter Assets
+        uses: vimtor/action-zip@v1
+        with:
+          files: ETL/Informatica PowerCenter/
+          recursive: false
+          dest: informatica-powercenter_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip
+
       - name: Verify ZIP files
         run: |
           # Verify that all ZIP files were created successfully
@@ -193,7 +200,8 @@ jobs:
             AlternativeSQLServerExtractionMethods_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip \
             synapse_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip \
             sybase-iq_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip \
-            power-bi_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip
+            power-bi_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip \
+            informatica-powercenter_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip
           do
             if [ ! -f "$file" ]; then
               echo "Error: ZIP file '$file' was not created!"
@@ -223,6 +231,7 @@ jobs:
             synapse_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip
             sybase-iq_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip
             power-bi_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip
+            informatica-powercenter_v${{ steps.get_version.outputs.VERSION_DOTS }}.zip
       
       - name: Summary
         run: |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ This repository contains utility scripts for exporting database objects from var
 - [BigQuery](./BigQuery)
 - [Databricks](./Databricks)
 - [Sybase IQ](./Sybase%20IQ/)
+- [Power BI](./Power%20BI/)
+
+## Supported ETL Tools
+
+- [Informatica PowerCenter](./ETL/Informatica%20PowerCenter/)
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
## Why

[PR #42](https://github.com/Snowflake-Labs/SC.DDLExportScripts/pull/42) added the new folder `ETL/Informatica PowerCenter/` (workflow extraction script + README), but the release pipeline was **never updated to know about it**. As a result:

- It is **not validated** by `use-build.yml` (a missing folder would not fail the build).
- It is **not packaged** into a ZIP.
- It is **not uploaded** as a build artifact.
- It is **not attached** to the GitHub Release (neither versioned nor as a permalink).
- It is **not mentioned** in the auto-generated release notes.

This PR wires it in following the existing convention used for every database engine: **one folder = one ZIP**.

## ZIP naming

Following the existing kebab-case pattern (`db2`, `power-bi`, `sybase-iq`, `sql-server`, …):

- Versioned asset: `informatica-powercenter_v<X.Y.Z>.zip`
- Permalink asset: `informatica-powercenter.zip`

The folder lives under `ETL/` in the repo, but the asset stays flat (no `etl-` prefix) for consistency with how every other engine is named at the release surface. If we ever add more ETL tools (Talend, SSIS, …), each will get its own flat ZIP.

## Changes

### `.github/workflows/use-build.yml`
- Add `\"ETL/Informatica PowerCenter\"` to the directory validation list (build fails fast if the folder disappears).
- New `vimtor/action-zip` step → `informatica-powercenter_v<version>.zip`.
- Add the new ZIP to the ZIP verification loop.
- Add the new ZIP to the artifact upload list.

### `.github/workflows/release.yml`
- Create the permalink `informatica-powercenter.zip` alongside the others.
- Upload both the versioned ZIP and the permalink ZIP as release assets.
- New \`add_component_changes \"Informatica PowerCenter (ETL)\" \"ETL/Informatica PowerCenter/\"\` so changes in this folder show up in the auto-generated release notes.
- Add \`Informatica PowerCenter (ETL)\` to the \"Included Components\" section of the release notes.

### Docs
- `README.md` (root): new **\"Supported ETL Tools\"** section with a link to `ETL/Informatica PowerCenter/`. Also added the previously-missing **Power BI** link to the database list while I was there (it was packaged but not listed).
- `.github/docs/RELEASE_PROCESS.md`: `ETL/Informatica PowerCenter` added to the list of engines packaged by `use-build.yml`.

## Out of scope / follow-up

- `prerelease.yml` (PR #44, not yet merged) will need the same `informatica-powercenter` entry in its asset list. I'll patch it on top once #44 lands.
- Pre-existing workflow lint warnings (`Context access might be invalid: version_dots`) are linter false positives — `use-build.yml` does declare those outputs. Not touched here.

## Test plan

- [ ] CI on this PR builds all 15 ZIPs (was 14) and uploads them as artifacts.
- [ ] Verify the artifact `ddl-export-scripts-pr-v<X.Y.Z>` contains `informatica-powercenter_v<X.Y.Z>.zip`.
- [ ] Inspect the ZIP: should contain `README.md` + `export_all_workflows.py` from `ETL/Informatica PowerCenter/`.
- [ ] After merge to `main`, confirm the next `cd.yml` run publishes the new ZIP (versioned + permalink) on the GitHub Release and that the release notes \"Component Changes\" section mentions Informatica PowerCenter when relevant.