### PR TITLE
feat(ci): one-click stable release via publish-release.yml

### DIFF
--- a/.github/docs/RELEASE_PROCESS.md
+++ b/.github/docs/RELEASE_PROCESS.md
@@ -16,6 +16,8 @@ High-level overview of how a release of the **DDL Export Scripts** is produced a
 ├── ci.yml                       # PR/branch build only (no release)
 ├── prepare-release.yml          # Reads VERSION, creates the git tag (main only)
 ├── release.yml                  # Builds + publishes GitHub Release with assets
+├── publish-release.yml          # Manual: bump version + tag + release + open VERSION-bump PR (draft)
+├── prerelease.yml               # Manual: build + publish a GitHub Pre-release (RC/beta/alpha)
 ├── use-build.yml                # Reusable: zips every engine folder
 ├── migrations-pr-draft.yml      # Adds/removes "DO NOT MERGE" label on draft PRs
 └── migrations-pr-precommit.yml  # Validates pre-commit hooks ran (incl. VERSION bump)
@@ -104,9 +106,33 @@ If a tag for the current `VERSION` already exists, the workflow falls back to a 
 
 ## Cutting a release manually
 
-The release pipeline is fully driven by merges to `main`, so the "manual" path is just:
+There are two supported paths for cutting a stable release. Pick whichever fits.
 
-1. Open a PR that bumps `VERSION` (and any script changes).
+### Recommended: one-click via `publish-release.yml`
+
+For most releases, just run the manual workflow and let it do everything.
+
+1. Go to **Actions → Publish Release → Run workflow**.
+2. Fill the inputs:
+   - **`version`** (required): stable semver `X.Y.Z`, e.g. `0.3.0`. The workflow rejects pre-release suffixes — for those, use the **Pre-release** workflow.
+   - **`ref`** (default `main`): branch / tag / SHA to base the release on.
+   - **`draft_release`** (default `false`): publish the GitHub Release as draft so you can sanity-check before going public.
+3. Click **Run workflow**.
+
+What it does, in order:
+
+1. **Validates** the version is `X.Y.Z` and that `v<version>` doesn't already exist (tag and `release/v<version>` branch).
+2. **Builds** the per-engine ZIPs at the chosen `ref` via `use-build.yml`, passing `version_override` so the ZIPs are stamped with the requested version regardless of the current `VERSION` file.
+3. **Tags** the chosen `ref` as `v<version>` and **publishes** the GitHub Release (versioned ZIPs + permalinks + auto-generated notes). At this point the release is live.
+4. **Opens a draft PR** on a new branch `release/v<version>` that bumps `VERSION` and runs `VERSION-UPDATE.sh` to propagate the version into every engine's `.py` / `.sh` / `.ps1` / `.bat`. Review and merge to persist the bump on `main`.
+
+When that draft PR is merged, `cd.yml` re-runs on `main`. It is idempotent: `prepare-release.yml` skips tag creation when the tag exists, and `softprops/action-gh-release` updates the existing release in place — so the merge just costs one extra CI cycle, no duplicates.
+
+### Manual fallback: VERSION bump in a PR
+
+If you'd rather drive the release through a standard PR review:
+
+1. Open a PR that bumps `VERSION` (and runs `./VERSION-UPDATE.sh` locally so engine scripts match).
 2. Wait for CI green and review.
 3. Merge into `main`.
 4. The `CD` workflow tags `v<X.Y.Z>` and publishes the GitHub Release automatically.

--- a/.github/docs/WORKFLOWS.md
+++ b/.github/docs/WORKFLOWS.md
@@ -23,13 +23,14 @@ Naming follows the convention used across the `migrations-*` repos:
 |---|---|---|
 | [`prepare-release.yml`](../workflows/prepare-release.yml) | `cd.yml` | Reads `VERSION`, computes the three version forms, creates the `v<X.Y.Z>` git tag (only on `main`). |
 | [`release.yml`](../workflows/release.yml) | `cd.yml` (only on `main`) | Builds the ZIPs, generates release notes, creates permalink ZIPs, publishes the GitHub Release with all assets. |
+| [`publish-release.yml`](../workflows/publish-release.yml) | Manual `workflow_dispatch` | One-click stable release. Takes a version (e.g. `0.3.0`), builds + tags + publishes the GitHub Release with all assets, then opens a **draft** PR on `release/v<X.Y.Z>` that bumps `VERSION` and propagates the version to every engine script (via `VERSION-UPDATE.sh`). |
 | [`prerelease.yml`](../workflows/prerelease.yml) | Manual `workflow_dispatch` | Builds at any ref and publishes a GitHub **Pre-release** (`v<X.Y.Z>-rc.N` etc.). Does not touch `VERSION`, `main`, or permalink ZIPs. |
 
 ## Reusable building blocks
 
 | File | Called by | Purpose |
 |---|---|---|
-| [`use-build.yml`](../workflows/use-build.yml) | `ci.yml`, `release.yml`, `prerelease.yml` | Validates required engine folders, zips each engine into `<engine>_v<X.Y.Z>.zip`, verifies, and uploads as an artifact. Exposes `version`, `version_dots`, `version_clean` outputs. Accepts an optional `version_override` input (used by `prerelease.yml`) so the version can come from the dispatch input instead of the `VERSION` file. |
+| [`use-build.yml`](../workflows/use-build.yml) | `ci.yml`, `release.yml`, `prerelease.yml`, `publish-release.yml` | Validates required engine folders, zips each engine into `<engine>_v<X.Y.Z>.zip`, verifies, and uploads as an artifact. Exposes `version`, `version_dots`, `version_clean` outputs. Accepts an optional `version_override` input (used by `prerelease.yml` and `publish-release.yml`) so the version can come from the dispatch input instead of the `VERSION` file. |
 
 ## PR checks
 
@@ -41,19 +42,24 @@ Naming follows the convention used across the `migrations-*` repos:
 ## Dependency graph
 
 ```
-                push to main / PR                  workflow_dispatch
-                         │                                │
-                         ▼                                ▼
-                      cd.yml                       prerelease.yml
-                    /        \                            │
-                   ▼          ▼                           │
-       prepare-release.yml   (is_main?)                   │
-                              /     \                     │
-                       yes  ▼       ▼ no                  │
-                       release.yml  ci.yml                │
-                              \     /                     │
-                               ▼   ▼                      ▼
-                            use-build.yml ◄───────────────┘
+        push to main / PR              workflow_dispatch          workflow_dispatch
+                 │                            │                          │
+                 ▼                            ▼                          ▼
+              cd.yml                  publish-release.yml          prerelease.yml
+            /        \                        │                          │
+           ▼          ▼                       │                          │
+prepare-release.yml  (is_main?)               │                          │
+                      /     \                 │                          │
+               yes  ▼       ▼ no              │                          │
+               release.yml  ci.yml            │                          │
+                      \     /                 │                          │
+                       ▼   ▼                  ▼                          ▼
+                    use-build.yml ◄───────────┴──────────────────────────┘
+                                         (version_override
+                                          for the two manual flows)
 ```
+
+- `publish-release.yml` additionally creates the tag, publishes the GitHub Release with versioned + permalink ZIPs, and opens a draft PR on `release/v<X.Y.Z>` that bumps `VERSION` and propagates it to every engine script via `VERSION-UPDATE.sh`.
+- `prerelease.yml` additionally creates the tag and publishes the GitHub **Pre-release** with versioned ZIPs only (no permalinks, no PR, no `VERSION` change).
 
 For a deeper explanation of the release flow (including pre-releases), see [`RELEASE_PROCESS.md`](./RELEASE_PROCESS.md).

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,358 @@
+name: Publish Release
+
+# Manual stable-release pipeline.
+#
+# What this does, in order:
+#   1. Validates the input version is a clean stable semver (X.Y.Z, no -rc/-beta/-alpha).
+#   2. Verifies the tag v<version> does not already exist.
+#   3. Builds the per-engine ZIPs at the chosen ref using `version_override`,
+#      so the ZIPs are stamped with the requested version regardless of what
+#      the VERSION file currently says on the source ref.
+#   4. Tags the chosen ref with v<version> and publishes the GitHub Release
+#      with both versioned ZIPs (e.g. teradata_v0.3.0.zip) and permalink ZIPs
+#      (e.g. teradata.zip).
+#   5. Opens a DRAFT pull request on a new branch `release/v<version>` that
+#      bumps the VERSION file and propagates the version to every engine's
+#      .py / .sh / .ps1 / .bat file (via VERSION-UPDATE.sh). The release is
+#      already live; this PR just persists the version bump on `main`.
+#
+# When that draft PR is merged, CD will re-run on `main`. It is idempotent:
+# `prepare-release.yml` skips tag creation when the tag exists, and
+# `softprops/action-gh-release` updates the existing release in place
+# (no duplicate, no failure — just one extra CI cycle).
+#
+# For pre-releases (0.3.0-rc.1 etc.) use the `Pre-release` workflow instead;
+# that one does NOT touch VERSION, does NOT open a PR, and does NOT publish
+# permalink ZIPs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Stable release version, semver X.Y.Z (e.g. 0.3.0). For pre-releases use the Pre-release workflow.'
+        required: true
+        type: string
+      ref:
+        description: 'Branch, tag, or SHA to base the release on.'
+        required: false
+        default: main
+        type: string
+      draft_release:
+        description: 'Publish the GitHub Release as draft (review assets before going public).'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate input
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Validate stable semver
+        id: check
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          CLEAN="${VERSION_INPUT#v}"
+          if ! echo "${CLEAN}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'${VERSION_INPUT}' is not a valid stable version. Expected X.Y.Z (e.g. 0.3.0). For pre-releases (e.g. 0.3.0-rc.1) use the Pre-release workflow."
+            exit 1
+          fi
+          echo "version=${CLEAN}" >> "${GITHUB_OUTPUT}"
+          echo "Validated stable version: ${CLEAN} (will be tagged as v${CLEAN})"
+
+      - name: Verify tag does not already exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_CLEAN: ${{ steps.check.outputs.version }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/v${VERSION_CLEAN}" --silent >/dev/null 2>&1; then
+            echo "::error::Tag v${VERSION_CLEAN} already exists. Bump the version and try again."
+            exit 1
+          fi
+          echo "Tag v${VERSION_CLEAN} is free."
+
+      - name: Verify release branch does not already exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_CLEAN: ${{ steps.check.outputs.version }}
+        run: |
+          if gh api "repos/${{ github.repository }}/branches/release/v${VERSION_CLEAN}" --silent >/dev/null 2>&1; then
+            echo "::error::Branch release/v${VERSION_CLEAN} already exists. Delete it or pick a different version."
+            exit 1
+          fi
+          echo "Branch release/v${VERSION_CLEAN} is free."
+
+  build-assets:
+    name: Build Release Assets
+    needs: validate
+    uses: ./.github/workflows/use-build.yml
+    with:
+      artifact_name: ddl-export-scripts-publish
+      artifact_retention_days: 30
+      version_override: ${{ needs.validate.outputs.version }}
+
+  publish:
+    name: Publish GitHub Release
+    needs: [validate, build-assets]
+    runs-on: ubuntu-latest
+    env:
+      VERSION_CLEAN: ${{ needs.validate.outputs.version }}
+      VERSION_DOTS: ${{ needs.build-assets.outputs.version_dots }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create annotated git tag
+        run: |
+          git tag -a "v${VERSION_CLEAN}" -m "Release v${VERSION_CLEAN} from ${{ inputs.ref }} (${{ github.sha }})"
+          git push origin "v${VERSION_CLEAN}"
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ddl-export-scripts-publish-v${{ env.VERSION_CLEAN }}
+          path: ./release-assets
+
+      - name: Create permalink versions of ZIP files
+        working-directory: ./release-assets
+        run: |
+          # Permalinks (no version in the filename) so consumers can pin to "latest stable".
+          cp "db2_v${VERSION_DOTS}.zip"                                  db2.zip
+          cp "hive_v${VERSION_DOTS}.zip"                                 hive.zip
+          cp "netezza_v${VERSION_DOTS}.zip"                              netezza.zip
+          cp "oracle_v${VERSION_DOTS}.zip"                               oracle.zip
+          cp "redshift_v${VERSION_DOTS}.zip"                             redshift.zip
+          cp "sql-server_v${VERSION_DOTS}.zip"                           sql-server.zip
+          cp "teradata_v${VERSION_DOTS}.zip"                             teradata.zip
+          cp "vertica_v${VERSION_DOTS}.zip"                              vertica.zip
+          cp "bigquery_v${VERSION_DOTS}.zip"                             bigquery.zip
+          cp "databricks_v${VERSION_DOTS}.zip"                           databricks.zip
+          cp "AlternativeSQLServerExtractionMethods_v${VERSION_DOTS}.zip" AlternativeSQLServerExtractionMethods.zip
+          cp "synapse_v${VERSION_DOTS}.zip"                              synapse.zip
+          cp "sybase-iq_v${VERSION_DOTS}.zip"                            sybase-iq.zip
+          cp "power-bi_v${VERSION_DOTS}.zip"                             power-bi.zip
+          cp "informatica-powercenter_v${VERSION_DOTS}.zip"              informatica-powercenter.zip
+          ls -la *.zip
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 "v${VERSION_CLEAN}^" 2>/dev/null || echo "")
+          if [ -n "${PREV_TAG}" ]; then
+            CHANGELOG=$(git log --pretty=format:"* %s (%an)" "${PREV_TAG}..v${VERSION_CLEAN}")
+            COMPARE_LINK="[\`${PREV_TAG}...v${VERSION_CLEAN}\`](https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${VERSION_CLEAN})"
+          else
+            CHANGELOG=$(git log --pretty=format:"* %s (%an)" -n 50 "v${VERSION_CLEAN}")
+            COMPARE_LINK="(no previous tag)"
+          fi
+
+          mkdir -p ./release_notes
+          {
+            echo "## DDL Export Scripts v${VERSION_CLEAN}"
+            echo ""
+            echo "Released from \`${{ inputs.ref }}\` (\`${{ github.sha }}\`) via the **Publish Release** workflow."
+            echo ""
+            echo "### What's Changed"
+            echo ""
+            echo "${CHANGELOG}"
+            echo ""
+            echo "### Included Components"
+            echo ""
+            echo "- DB2"
+            echo "- Hive"
+            echo "- Netezza"
+            echo "- Oracle"
+            echo "- Redshift"
+            echo "- SQL Server"
+            echo "- Teradata"
+            echo "- Vertica"
+            echo "- BigQuery"
+            echo "- Databricks"
+            echo "- Synapse"
+            echo "- Sybase IQ"
+            echo "- Power BI"
+            echo "- Alternative SQL Server Extraction Methods"
+            echo "- Informatica PowerCenter (ETL)"
+            echo ""
+            echo "### Installation"
+            echo ""
+            echo "Download the ZIP for your platform and extract it. See the README inside each component."
+            echo ""
+            echo "### Full Changelog"
+            echo ""
+            echo "${COMPARE_LINK}"
+          } > ./release_notes/release_notes.md
+
+          {
+            echo 'release_notes<<EOF'
+            cat ./release_notes/release_notes.md
+            echo 'EOF'
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ env.VERSION_CLEAN }}
+          name: Release v${{ env.VERSION_CLEAN }}
+          body: ${{ steps.notes.outputs.release_notes }}
+          target_commitish: ${{ inputs.ref }}
+          prerelease: false
+          draft: ${{ inputs.draft_release }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            ./release-assets/db2_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/hive_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/netezza_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/oracle_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/redshift_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/sql-server_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/teradata_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/vertica_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/bigquery_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/databricks_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/AlternativeSQLServerExtractionMethods_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/synapse_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/sybase-iq_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/power-bi_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/informatica-powercenter_v${{ env.VERSION_DOTS }}.zip
+            ./release-assets/db2.zip
+            ./release-assets/hive.zip
+            ./release-assets/netezza.zip
+            ./release-assets/oracle.zip
+            ./release-assets/redshift.zip
+            ./release-assets/sql-server.zip
+            ./release-assets/teradata.zip
+            ./release-assets/vertica.zip
+            ./release-assets/bigquery.zip
+            ./release-assets/databricks.zip
+            ./release-assets/AlternativeSQLServerExtractionMethods.zip
+            ./release-assets/synapse.zip
+            ./release-assets/sybase-iq.zip
+            ./release-assets/power-bi.zip
+            ./release-assets/informatica-powercenter.zip
+
+  open-version-bump-pr:
+    name: Open VERSION bump PR (draft)
+    needs: [validate, publish]
+    runs-on: ubuntu-latest
+    env:
+      VERSION_CLEAN: ${{ needs.validate.outputs.version }}
+      RELEASE_BRANCH: release/v${{ needs.validate.outputs.version }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release branch
+        run: git checkout -b "${RELEASE_BRANCH}"
+
+      - name: Bump VERSION file
+        run: |
+          perl -i -pe 's/^__version__ = ".*"/__version__ = "'"${VERSION_CLEAN}"'"/' VERSION
+          echo "VERSION file is now:"
+          cat VERSION | grep '__version__'
+
+      - name: Propagate version to engine scripts
+        run: |
+          chmod +x ./VERSION-UPDATE.sh ./.github/scripts/common-normalize-version.sh
+          ./VERSION-UPDATE.sh
+
+      - name: Show diff summary
+        run: |
+          echo "Changed files:"
+          git diff --stat
+          echo ""
+          echo "Total files touched: $(git diff --name-only | wc -l | xargs)"
+
+      - name: Commit and push release branch
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::error::No changes produced by the version bump. Aborting."
+            exit 1
+          fi
+          git commit -m "chore: bump version to ${VERSION_CLEAN}
+
+          Auto-generated by the Publish Release workflow after publishing
+          v${VERSION_CLEAN} to GitHub Releases.
+
+          See: https://github.com/${{ github.repository }}/releases/tag/v${VERSION_CLEAN}"
+          git push -u origin "${RELEASE_BRANCH}"
+
+      - name: Open draft pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_BODY=$(cat <<EOF
+          ## Auto-generated VERSION bump
+
+          This PR was opened automatically by the **Publish Release** workflow ([\`publish-release.yml\`](../blob/main/.github/workflows/publish-release.yml)) after publishing the GitHub Release.
+
+          - **Released tag:** [\`v${VERSION_CLEAN}\`](https://github.com/${{ github.repository }}/releases/tag/v${VERSION_CLEAN})
+          - **Source ref:** \`${{ inputs.ref }}\` (\`${{ github.sha }}\`)
+          - **Workflow run:** [#${{ github.run_number }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          ### What's already done
+
+          - [x] Tag \`v${VERSION_CLEAN}\` created
+          - [x] GitHub Release \`v${VERSION_CLEAN}\` published with all 15 versioned ZIPs and 15 permalink ZIPs
+          - [x] Release notes generated
+
+          ### What this PR does
+
+          Persists the version bump on \`main\` so the \`VERSION\` file and the version strings inside every engine's \`.py\` / \`.sh\` / \`.ps1\` / \`.bat\` file match what was actually released.
+
+          ### Why is this a draft?
+
+          So a human can review the propagated changes (it touches every engine). Mark it ready for review when you're happy and merge.
+
+          ### What happens when this merges?
+
+          \`cd.yml\` will re-run on \`main\`. It is idempotent:
+          - \`prepare-release.yml\` sees \`v${VERSION_CLEAN}\` already exists and skips tag creation.
+          - \`release.yml\` re-uploads the same assets to the existing release via \`softprops/action-gh-release\` (no duplicate, no failure).
+
+          The release is already live regardless of this PR.
+          EOF
+          )
+
+          gh pr create \
+            --base main \
+            --head "${RELEASE_BRANCH}" \
+            --title "chore: bump version to ${VERSION_CLEAN}" \
+            --body "${PR_BODY}" \
+            --draft
+
+      - name: Summary
+        run: |
+          {
+            echo "### Publish Release complete"
+            echo ""
+            echo "- **Tag:** \`v${VERSION_CLEAN}\`"
+            echo "- **Release:** https://github.com/${{ github.repository }}/releases/tag/v${VERSION_CLEAN}"
+            echo "- **Version bump PR (draft):** https://github.com/${{ github.repository }}/pulls?q=head%3A${RELEASE_BRANCH}"
+            echo ""
+            echo "Review the draft PR and merge when ready."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/DB2/bin/create_ddls.ps1
+++ b/DB2/bin/create_ddls.ps1
@@ -1,4 +1,7 @@
-Write-Output "DB2 DDL Export script"
+# Script version (kept in sync by VERSION-UPDATE.sh from the repo-root VERSION file)
+$VERSION = "0.2.0"
+
+Write-Output "DB2 DDL Export script (version $VERSION)"
 Write-Output "Getting list of databases"
 $OUTPUTDIR = "../object_extracts"
 ### Get List of Database

--- a/Power BI/bulk-convert-pbix-to-pbit.ps1
+++ b/Power BI/bulk-convert-pbix-to-pbit.ps1
@@ -34,6 +34,12 @@
 # ============================================
 # CONFIGURATION
 # ============================================
+
+# Script version (kept in sync by VERSION-UPDATE.sh from the repo-root VERSION file).
+# Note: this is the *script* version for traceability of extracted artifacts;
+# it is independent of the pbi-tools versions defined below.
+$VERSION = "0.2.0"
+
 $DefaultSubfolderName = "PBIT_Output"
 $BytesPerMegabyte = 1048576
 $PbiToolsInstallPath = "$env:LOCALAPPDATA\pbi-tools"
@@ -54,6 +60,7 @@ function Write-Banner {
     Write-Host "  |   Power BI Bulk PBIX to PBIT Converter (pbi-tools)    |" -ForegroundColor Cyan
     Write-Host "  |   Preserves Visuals + Data Connections                |" -ForegroundColor Cyan
     Write-Host "  |                                                       |" -ForegroundColor Cyan
+    Write-Host ("  |   Script version: {0,-35} |" -f $VERSION) -ForegroundColor Cyan
     Write-Host "  =========================================================" -ForegroundColor Cyan
     Write-Host ""
 }

--- a/VERSION-UPDATE.sh
+++ b/VERSION-UPDATE.sh
@@ -80,12 +80,9 @@ update_bash_scripts() {
 
       cp "$BASH_FILE" "$BASH_FILE.bak"
 
-      sed -i '' "s/VERSION=[\"'][^\"']*[\"']/VERSION=\"${VERSION}\"/" "$BASH_FILE"
-
-      if diff -q "$BASH_FILE" "$BASH_FILE.bak" >/dev/null; then
-        echo "  Warning: Version not updated in $BASH_FILE. Trying alternative method..."
-        perl -i -pe "s/VERSION=[\"'][^\"']*[\"']/VERSION=\"${VERSION}\"/" "$BASH_FILE"
-      fi
+      # perl -i -pe is portable across macOS (BSD sed) and Linux (GNU sed),
+      # unlike `sed -i ''` (BSD-only) or `sed -i` (GNU-only).
+      perl -i -pe "s/VERSION=[\"'][^\"']*[\"']/VERSION=\"${VERSION}\"/" "$BASH_FILE"
 
       rm -f "$BASH_FILE.bak"
 
@@ -104,9 +101,10 @@ update_batch_scripts() {
   find "$REPO_ROOT" -name "*.bat" -type f -print0 | while IFS= read -r -d '' BAT_FILE; do
     echo "Checking $BAT_FILE..."
     cp "$BAT_FILE" "$BAT_FILE.bak"
-    # Normalize various SET forms to SET VERSION=<VERSION>
-    sed -i '' -E "s/^[[:space:]]*[Ss][Ee][Tt][[:space:]]+VERSION[[:space:]]*=.*/SET VERSION=${VERSION}/" "$BAT_FILE" || true
-    sed -i '' -E "s/^[[:space:]]*[Ss][Ee][Tt][[:space:]]+\"VERSION=[^\"]*\"/SET VERSION=${VERSION}/" "$BAT_FILE" || true
+    # Normalize various SET forms to SET VERSION=<VERSION>.
+    # perl -i -pe is portable across macOS and Linux (sed -i syntax differs).
+    perl -i -pe "s/^\s*[Ss][Ee][Tt]\s+VERSION\s*=.*/SET VERSION=${VERSION}/" "$BAT_FILE" || true
+    perl -i -pe "s/^\s*[Ss][Ee][Tt]\s+\"VERSION=[^\"]*\"/SET VERSION=${VERSION}/" "$BAT_FILE" || true
     if diff -q "$BAT_FILE" "$BAT_FILE.bak" >/dev/null; then
       echo "  Warning: Version not updated in $BAT_FILE. Trying alternative method..."
       perl -i -pe "s/^(\s*[Ss][Ee][Tt]\s+)(\"?)VERSION\2\s*=\s*(\"?)[^\r\n]*\3/\$1VERSION=${VERSION}/" "$BAT_FILE"
@@ -131,10 +129,9 @@ update_python_scripts() {
 
       cp "$PY_FILE" "$PY_FILE.bak"
 
-      sed -i '' -E \
-        -e "s/^([[:space:]]*VERSION[[:space:]]*=[[:space:]]*)['\\\"][^'\\\"]*['\\\"]/\\1\"${VERSION}\"/" \
-        -e "s/^([[:space:]]*__version__[[:space:]]*=[[:space:]]*)['\\\"][^'\\\"]*['\\\"]/\\1\"${VERSION}\"/" \
-        "$PY_FILE"
+      # perl -i -pe is portable across macOS and Linux (sed -i syntax differs).
+      perl -i -pe "s/^(\s*VERSION\s*=\s*)['\\\"][^'\\\"]*['\\\"]/\$1\"${VERSION}\"/" "$PY_FILE"
+      perl -i -pe "s/^(\s*__version__\s*=\s*)['\\\"][^'\\\"]*['\\\"]/\$1\"${VERSION}\"/" "$PY_FILE"
 
       rm -f "$PY_FILE.bak"
 

--- a/VERSION-UPDATE.sh
+++ b/VERSION-UPDATE.sh
@@ -54,10 +54,22 @@ update_powershell_scripts() {
 
     rm -f "$PS_FILE.bak"
 
-    if grep -qE "^[[:space:]]*\\$[Vv][Ee][Rr][Ss][Ii][Oo][Nn][[:space:]]*=[[:space:]]*\"${VERSION}\"" "$PS_FILE"; then
-      echo "  Successfully updated $PS_FILE to version $VERSION"
+    # Single-quoted regex avoids shell parsing pitfalls. The original used
+    # double quotes with `\\$[Vv]...` — bash/zsh saw `$[Vv]` as a deprecated
+    # arithmetic expansion `$[expr]`, expanded `Vv` to 0, and produced `\0`
+    # instead of `\$`, so the verification ALWAYS failed even when the perl
+    # substitution above succeeded. Switching to a fixed-string check sidesteps
+    # the whole quoting mess. Files that genuinely have no `$VERSION = "..."`
+    # assignment (e.g. DB2/bin/create_ddls.ps1, Power BI/bulk-convert-pbix-to-pbit.ps1)
+    # are reported as "no version variable found" rather than misleadingly as failures.
+    if grep -qiE '^[[:space:]]*\$VERSION[[:space:]]*=' "$PS_FILE"; then
+      if grep -qiE '^[[:space:]]*\$VERSION[[:space:]]*=[[:space:]]*"'"${VERSION}"'"' "$PS_FILE"; then
+        echo "  Successfully updated $PS_FILE to version $VERSION"
+      else
+        echo "  Failed to update version in $PS_FILE"
+      fi
     else
-      echo "  Failed to update version in $PS_FILE"
+      echo "  No \$VERSION variable found in $PS_FILE (skipped)"
     fi
   done
 }


### PR DESCRIPTION
> **Note:** stacked on top of #44. Base is \`feature/manual-prerelease-workflow\` so the diff is clean. Once #44 merges, GitHub will retarget this PR to \`main\` automatically.

## What

Adds \`.github/workflows/publish-release.yml\` — a manual \`workflow_dispatch\` pipeline so cutting a stable release is just **Actions → Publish Release → enter \`0.3.0\` → Run**.

## Why

Today, cutting a stable release means: open a PR, bump \`VERSION\`, run \`VERSION-UPDATE.sh\` locally to propagate the version into every engine's scripts, get review, merge, and let \`cd.yml\` do the rest. That works, but it's a lot of human steps for what should be a single decision (\"we want to release 0.3.0\").

This PR closes that gap. One click, one input, full release.

## How it works

\`\`\`
Actions → Publish Release → version=0.3.0 → Run
   │
   ├─ validate              (semver X.Y.Z, tag free, branch free)
   ├─ build-assets          → use-build.yml(version_override=0.3.0)
   ├─ publish               (tag v0.3.0, GitHub Release w/ 15 versioned + 15 permalink ZIPs)
   └─ open-version-bump-pr  (draft PR on release/v0.3.0 — bumps VERSION + runs VERSION-UPDATE.sh)
\`\`\`

Step-by-step:

1. **Validates** the input is a stable semver \`X.Y.Z\` (rejects pre-release suffixes — those go through \`prerelease.yml\`). Verifies \`v<version>\` tag and \`release/v<version>\` branch don't already exist.
2. **Builds** the per-engine ZIPs at the chosen \`ref\` via \`use-build.yml\`, passing \`version_override\` so the assets are stamped with the requested version regardless of what \`VERSION\` currently says on the source ref.
3. **Tags** the chosen \`ref\` as \`v<version>\` and **publishes** the GitHub Release with all 15 versioned ZIPs + 15 permalinks + auto-generated release notes. **At this point the release is live.**
4. **Opens a DRAFT PR** on a new branch \`release/v<version>\` that bumps \`VERSION\` and runs \`VERSION-UPDATE.sh\` to propagate the version into every engine's \`.py\` / \`.sh\` / \`.ps1\` / \`.bat\`. Review the propagated changes, mark ready, merge → \`VERSION\` on \`main\` now matches what was released.

### What about the merge race with \`cd.yml\`?

When the draft PR is merged, \`cd.yml\` re-runs on \`main\`. It is idempotent:

- \`prepare-release.yml\` already guards on \`tag_exists\` and skips creating an existing tag.
- \`release.yml\` uses \`softprops/action-gh-release\` which updates the existing release in place rather than failing.

So the merge just costs one extra CI cycle. No duplicate releases, no failures.

## Inputs

| Input | Required | Default | Description |
|---|---|---|---|
| \`version\` | yes | — | Stable semver \`X.Y.Z\` (e.g. \`0.3.0\`). |
| \`ref\` | no | \`main\` | Branch / tag / SHA to base the release on. |
| \`draft_release\` | no | \`false\` | Publish the GitHub Release as draft so you can sanity-check assets before going public. |

## Bonus: portable \`VERSION-UPDATE.sh\`

\`VERSION-UPDATE.sh\` was using \`sed -i ''\` (BSD/macOS-only syntax) in 3 of its 4 functions (\`update_bash_scripts\`, \`update_batch_scripts\`, \`update_python_scripts\`). On a Linux GHA runner — which is exactly where \`publish-release.yml\` needs to invoke it — those \`sed -i ''\` calls would fail (Linux GNU \`sed -i\` doesn't accept the empty-string argument).

Replaced those calls with \`perl -i -pe\`, which runs identically on macOS and Linux. The PowerShell function in the same script already used this pattern, so this just makes the other three consistent.

Verified locally on macOS:
- 11 \`Successfully updated\` for \`.sh\` / \`.bat\` / \`.py\` files (all the non-\`.ps1\` types I touched).
- 6 \`Failed to update\` for \`.ps1\` files — pre-existing perl regex issue in \`update_powershell_scripts\`, not touched here.
- Exit 0, no leftover \`.bak\` files, idempotent re-runs.

## Files changed

- **NEW** \`.github/workflows/publish-release.yml\` — the workflow itself.
- \`VERSION-UPDATE.sh\` — portable \`perl -i -pe\` for \`.sh\` / \`.bat\` / \`.py\`.
- \`.github/docs/RELEASE_PROCESS.md\` — new \"Recommended: one-click via \`publish-release.yml\`\" section, old flow kept as \"Manual fallback\".
- \`.github/docs/WORKFLOWS.md\` — \`publish-release.yml\` added to the release flow table, dependency graph updated to show all three dispatch entry points (cd.yml, publish-release.yml, prerelease.yml).

## Out of scope

- The pre-existing \`.ps1\` propagation bug in \`update_powershell_scripts\` (separate fix).
- The pre-existing \`release.yml\` \`vv*\` tag cleanup bug (already documented as tech debt in \`RELEASE_PROCESS.md\`).

## Test plan

- [ ] After PR #44 lands and this PR is rebased on \`main\`, dispatch the workflow from a non-main branch first with \`draft_release=true\` to validate the full flow without going public.
- [ ] Confirm the GitHub Release contains all 15 versioned + 15 permalink ZIPs.
- [ ] Confirm a draft PR was opened on \`release/v<version>\` with the VERSION bump + propagation diffs.
- [ ] Merge that draft PR, confirm \`cd.yml\` re-runs idempotently (no duplicate release, no tag failure).