### PR TITLE
fix(ci): trim Test ETL Scripts triggers to PRs, main, and manual

### DIFF
--- a/.github/workflows/test-etl-scripts.yml
+++ b/.github/workflows/test-etl-scripts.yml
@@ -2,7 +2,7 @@ name: Test ETL Scripts
 
 on:
   push:
-    branches: [main, "support/*", "feature/*", "bugfix/*", "sfc-gh-*/*"]
+    branches: [main]
     paths:
       - "ETL/**"
       - "Tests/ETL/**"
@@ -13,6 +13,7 @@ on:
       - "ETL/**"
       - "Tests/ETL/**"
       - "requirements-test.txt"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

\`test-etl-scripts.yml\` (added in #42) was wired to run on every push to \`main\`, \`support/*\`, \`feature/*\`, \`bugfix/*\`, and \`sfc-gh-*/*\` branches. That:

- **Doubles up with the PR run.** Every commit pushed to a branch with an open PR runs the suite twice (once via \`push\`, once via \`pull_request\`).
- **Burns CI on in-progress work.** Feature branches without a PR yet still trigger the full ETL test suite on every push.

That doesn't match how the rest of the repo handles CI vs CD.

## What this PR does

Aligns the triggers with the standard pattern used by the other workflows here:

| Trigger | Before | After |
|---|---|---|
| \`pull_request\` (any branch) | yes | yes (CI signal on the PR) |
| \`push\` to \`main\` | yes | yes (CD signal after merge) |
| \`push\` to \`support/*\`, \`feature/*\`, \`bugfix/*\`, \`sfc-gh-*/*\` | yes | **removed** |
| \`workflow_dispatch\` | no | **added** (on-demand re-run from the Actions tab) |

The \`paths\` filters (\`ETL/**\`, \`Tests/ETL/**\`, \`requirements-test.txt\`) and the test job itself are unchanged.

## Test plan

- [ ] Push a commit to a non-main branch with no PR → \`Test ETL Scripts\` should NOT run.
- [ ] Open a PR touching \`ETL/**\` → \`Test ETL Scripts\` runs once.
- [ ] Merge the PR → \`Test ETL Scripts\` runs once on \`main\`.
- [ ] Trigger from Actions tab manually → \`Test ETL Scripts\` runs.