### PR TITLE
fix(ci): short-circuit cd.yml when GitHub Release for VERSION already exists

### DIFF
--- a/.github/docs/RELEASE_PROCESS.md
+++ b/.github/docs/RELEASE_PROCESS.md
@@ -40,10 +40,13 @@ High-level overview of how a release of the **DDL Export Scripts** is produced a
 ```mermaid
 flowchart LR
     A[Push to main] --> B[cd.yml]
-    B --> C[prepare-release.yml<br/>Read VERSION → create tag v&lt;X.Y.Z&gt;]
+    B --> C[prepare-release.yml<br/>Read VERSION<br/>Check tag + GitHub Release exist]
     B --> D[check-context<br/>is_main = true]
-    C --> E[release.yml]
+    C -->|release_exists = true| K[release-skipped<br/>Log notice + exit]
+    C -->|release_exists = false| E[release.yml]
     D --> E
+    C -->|tag missing| C2[Create tag v&lt;X.Y.Z&gt;]
+    C2 --> E
     E --> F[use-build.yml<br/>Build per-engine ZIPs<br/>Upload artifacts]
     F --> G[Download artifacts]
     G --> H[Generate release notes<br/>from git log + per-component diff]
@@ -53,6 +56,11 @@ flowchart LR
 
 On a PR, step **C** still runs (read-only — it does not push a tag because `is_main != 'true'`) and step **E** is replaced by `ci.yml`, which only uploads ZIP artifacts.
 
+The `release_exists` short-circuit makes the two release entry points orthogonal:
+
+- **One-click via `publish-release.yml`** — that workflow publishes the release itself, then opens a `release/v<version>` bump PR. When the bump PR merges, `cd.yml` sees the release already exists and runs only `prepare-release.yml` + `release-skipped` (no rebuild, no re-upload).
+- **Manual VERSION bump in a PR** — the legacy path. No prior release exists, so the short-circuit does not trigger and `cd.yml` runs the full build + publish.
+
 ## Versioning
 
 - The single source of truth is the [`VERSION`](../../VERSION) file at repo root, e.g. `__version__ = "0.2.0"`.
@@ -61,7 +69,7 @@ On a PR, step **C** still runs (read-only — it does not push a tag because `is
   - `VERSION_DOTS` → `0.2.0` (used in ZIP file names)
   - `VERSION_CLEAN` → `0.2.0` without any `v` prefix (used for the tag)
   - `VERSION` → `0_2_0` (underscored, for places that don't accept dots)
-  These are step outputs only — `prepare-release.yml` does not declare `workflow_call.outputs`, so they are **not** consumed by the caller workflow. `use-build.yml`, on the other hand, **does** expose `version`, `version_dots`, and `version_clean` as reusable-workflow outputs, and that is what `release.yml` reads.
+  `prepare-release.yml` exposes `version_clean`, `version_dots`, `tag_exists`, and `release_exists` as `workflow_call.outputs`, which `cd.yml` consumes to short-circuit a redundant build+publish cycle (see *End-to-end flow* below). `use-build.yml` separately exposes `version`, `version_dots`, and `version_clean`, which `release.yml` reads when wiring up download artifact paths.
 - The tag is always `v<VERSION_CLEAN>` (e.g. `v0.2.0`). Legacy `vv*` tags are **not** auto-cleaned today: `release.yml` has a cleanup step but its current condition (`if: tag_exists != 'true'`) prevents it from running when a `vv*` tag actually exists. Tracked as a separate workflow bug to fix outside this docs change.
 
 ## Artifacts
@@ -126,7 +134,9 @@ What it does, in order:
 3. **Tags** the chosen `ref` as `v<version>` and **publishes** the GitHub Release (versioned ZIPs + permalinks + auto-generated notes). At this point the release is live.
 4. **Opens a draft PR** on a new branch `release/v<version>` that bumps `VERSION` and runs `VERSION-UPDATE.sh` to propagate the version into every engine's `.py` / `.sh` / `.ps1` / `.bat`. Review and merge to persist the bump on `main`.
 
-When that draft PR is merged, `cd.yml` re-runs on `main`. It is idempotent: `prepare-release.yml` skips tag creation when the tag exists, and `softprops/action-gh-release` updates the existing release in place — so the merge just costs one extra CI cycle, no duplicates.
+When that draft PR is merged, `cd.yml` re-runs on `main`. `prepare-release.yml` checks whether a published GitHub Release for `v<version>` already exists; if so, `cd.yml` **skips** the build+publish jobs entirely and emits a `release-skipped` notice in the run summary. Net cost: one cheap `prepare-release` job (~10 s), no duplicate ZIP rebuild, no duplicate asset upload.
+
+If you ever need to **regenerate** the assets for an already-published version (e.g. recovering from a bad build), delete the GitHub Release on the Releases page and re-run `cd.yml` from the Actions tab — with the release gone, the short-circuit no longer fires and the full build+publish path runs.
 
 ### Manual fallback: VERSION bump in a PR
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,9 +60,33 @@ jobs:
   release-workflow:
     name: Create Release and Upload Assets (Main Branch)
     needs: [set-version, check-context]
-    if: needs.check-context.outputs.is_main == 'true'
+    # Skip when a GitHub Release for this VERSION already exists (typical after a
+    # publish-release.yml run that already built+published+opened the bump PR).
+    # This keeps the legacy "edit VERSION on a branch and merge" path working,
+    # and re-runs cleanly if someone manually deletes a release for recovery.
+    if: |
+      needs.check-context.outputs.is_main == 'true' &&
+      needs.set-version.outputs.release_exists != 'true'
     uses: ./.github/workflows/release.yml
     secrets: inherit
+
+  release-skipped:
+    name: Skip release (already published)
+    needs: [set-version, check-context]
+    if: |
+      needs.check-context.outputs.is_main == 'true' &&
+      needs.set-version.outputs.release_exists == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log skip reason
+        run: |
+          TAG="v${{ needs.set-version.outputs.version_clean }}"
+          echo "::notice::GitHub Release $TAG already exists. Skipping build + publish to avoid duplicate work."
+          echo ""
+          echo "This is the expected outcome when a 'Publish Release' run already created"
+          echo "the release and this CD run was triggered by the auto-merged VERSION bump PR."
+          echo ""
+          echo "If you need to regenerate assets for $TAG, delete the release on GitHub and re-run this workflow."
 
   package-workflow:
     name: Package Assets Only (PR/Branch)

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,4 +1,18 @@
-on: workflow_call
+on:
+  workflow_call:
+    outputs:
+      version_clean:
+        description: "Version from VERSION file without leading 'v' prefix"
+        value: ${{ jobs.set-version.outputs.version_clean }}
+      version_dots:
+        description: "Version with dots (e.g. 0.3.0)"
+        value: ${{ jobs.set-version.outputs.version_dots }}
+      tag_exists:
+        description: "Whether the git tag v<version> already exists"
+        value: ${{ jobs.set-version.outputs.tag_exists }}
+      release_exists:
+        description: "Whether a published GitHub Release for v<version> already exists"
+        value: ${{ jobs.set-version.outputs.release_exists }}
 
 name: Prepare Release
 
@@ -9,6 +23,11 @@ permissions:
 jobs:
   set-version:
     runs-on: ubuntu-latest
+    outputs:
+      version_clean: ${{ steps.get_version.outputs.VERSION_CLEAN }}
+      version_dots: ${{ steps.get_version.outputs.VERSION_DOTS }}
+      tag_exists: ${{ steps.check_tag.outputs.tag_exists }}
+      release_exists: ${{ steps.check_release.outputs.release_exists }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -63,6 +82,24 @@ jobs:
             # Get latest tag if no matching tag exists
             LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.1")
             echo "latest_tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for existing GitHub Release
+        id: check_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # A published GitHub Release for this VERSION means the assets were already
+          # uploaded by an earlier run (typically publish-release.yml). When CD is then
+          # triggered by the auto-merged VERSION bump PR, we want to short-circuit
+          # rather than rebuild and re-upload identical assets.
+          TAG="v${{ steps.get_version.outputs.VERSION_CLEAN }}"
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "GitHub Release $TAG already exists"
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No GitHub Release found for $TAG"
+            echo "release_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Bump version and push tag


### PR DESCRIPTION
## TL;DR

When `publish-release.yml` (one-click stable release) creates a GitHub Release and then opens the auto-merged `release/v<version>` bump PR, the merge to `main` re-triggers `cd.yml`, which **unconditionally rebuilds every per-engine ZIP and re-uploads them in-place** to the same release via `softprops/action-gh-release@v1`. Idempotent (so it does not fail), but wasted ~38 s of CI per release and produced two `Artifacts` entries with identical content.

This PR adds a `release_exists` check to `prepare-release.yml` and gates `cd.yml`'s `release-workflow` job on it. When a release for `v<version>` is already published, `cd.yml` exits in ~10 s with a `release-skipped` notice instead of rebuilding.

## Concrete example from the v0.3.0 attempt

[Run #1 of Publish Release](https://github.com/Snowflake-Labs/SC.DDLExportScripts/actions/runs/24697311611) (manual, ~53 s) and [CD #19](https://github.com/Snowflake-Labs/SC.DDLExportScripts/actions/runs/24697397709) (auto-triggered by the bump-PR merge, ~42 s) both built and published the **same** `v0.3.0` release with the **same** assets back-to-back.

```
00:21  Publish Release #1
       ├─ build-assets        (5s)
       ├─ Publish GitHub Release (15s)  → tag v0.3.0, release with 30 assets
       └─ Open VERSION bump PR  (12s)   → PR #48 opened

00:24  PR #48 merged → push to main → CD #19 (AUTO)
       ├─ set-version        (8s)   → tag_exists=true (publish-release made it)
       ├─ check-context      (5s)   → is_main=true
       ├─ build-assets       (12s)  → identical zips
       └─ Upload Release     (13s)  → softprops UPDATE in-place, no-op effective change

       Wasted: ~38s of CI doing exactly the same work.
```

## Why `cd.yml` did not skip before

`release.yml` already exposed a `tag_exists` output and used it to **branch the changelog** (manual vs auto-generated), but **never** to gate the build/publish jobs. `softprops/action-gh-release@v1` happily updates an existing release in-place, so the second pass succeeds — just at the cost of a duplicate run.

## The fix

### `prepare-release.yml`

- Now declares `workflow_call.outputs`: `version_clean`, `version_dots`, `tag_exists`, and a new `release_exists` (computed via `gh release view "v<version>" --repo "$REPO"`).
- The new `Check for existing GitHub Release` step uses the workflow's existing `GITHUB_TOKEN` (read on `contents` is already granted).

### `cd.yml`

- `release-workflow` job is now gated on `needs.set-version.outputs.release_exists != 'true'`.
- A new tiny `release-skipped` job runs in the opposite case and emits a `::notice::` annotation explaining why nothing was rebuilt.

### `.github/docs/RELEASE_PROCESS.md`

- Mermaid flow diagram updated with the short-circuit branch.
- Replaces the previous \"merge costs one extra CI cycle, no duplicates\" note with the now-true \"no duplicate rebuild\" guarantee.
- Documents the recovery path (delete the release manually → re-run cd.yml → full publish).

## Behavior matrix

| Trigger | `release_exists` | What runs | Cost |
|---|---|---|---|
| Bump-PR merge after `publish-release.yml` | `true` | `prepare-release` + `release-skipped` | ~10 s |
| Manual `VERSION` bump merged to main (legacy path) | `false` | `prepare-release` + full `release.yml` | ~50 s (unchanged) |
| Re-run after manual release deletion (recovery) | `false` | full `release.yml` | ~50 s (works out-of-the-box) |
| PR builds (any branch) | irrelevant | `prepare-release` + `package-workflow` (CI) | unchanged |

## Why this is safe

- Purely additive on top of the existing `tag_exists` logic — no behavior change when no release was previously published.
- `gh release view` requires only read on `contents`, which the workflow already has via `permissions:`.
- The gate is on the **release**, not the **tag**: if a tag exists without a release (e.g. someone created a tag manually for testing), the full publish path still runs and creates the release.
- The `release-skipped` job has no side effects — pure notice + log.
- Pull-request runs (any branch) are unaffected: `is_main != 'true'` short-circuits both `release-workflow` and `release-skipped`, leaving `package-workflow` (CI) as the only downstream.

## Diff summary

- `prepare-release.yml`: +27 LOC. Exposes 4 outputs and adds the `check_release` step.
- `cd.yml`: +20 LOC. `if:` guard on `release-workflow` + new `release-skipped` job.
- `.github/docs/RELEASE_PROCESS.md`: +14 / -4. Diagram + idempotency wording.

Net: **+71 LOC**, 3 files.

## Test plan

- [x] YAML lint clean (`yaml.safe_load`) for both `prepare-release.yml` and `cd.yml`
- [ ] CI passes on this PR (PR builds should hit `package-workflow` only, never the release-skipped path since it requires `is_main`)
- [ ] After merge: re-trigger `Publish Release` 0.3.0 → the auto-triggered `cd.yml` run on bump-PR merge shows the new `Skip release (already published)` job (not a second full build)

## Related

- #49 is the empty-ZIPs fix from the same incident; this PR is the second, independent improvement and does not depend on #49.